### PR TITLE
Add retry automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,20 @@ The feedback loop looks like this:
 
 ```mermaid
 flowchart TD
-    A([Central Thermostat]) <-->|Manipulate Setpoint| B((Home Assistant));
+    Z((Home Assistant))
+    W[/Mobile Device/]
 
-    B --> C(Room 1);
-    B --> D(Room 2);
-    B --> E(Room 3);
+    A((Manipulate Central Thermostat))
+    B(Google Cloud Service Pub/Sub)
+
+    Z --> | 1 - Publish setpoint change | B
+    Z .-> | 2 - Retry on failure x3 | B
+    B --> A
+    Z .-> | 3 - Notify after 3 failures to retry | W
+
+    Z --> C(Room 1);
+    Z --> D(Room 2);
+    Z --> E(Room 3);
 
     F{Is room temperature above setpoint?};
     G([Continue monitoring temperature]);
@@ -59,7 +68,7 @@ flowchart TD
     F --> I;
     I .-> J;
     J .-> K;
-    K .-> B;
+    K .-> Z;
 ```
 
 ## Getting Started

--- a/automations/Modify Central Thermostat/retry-on-failure.yml
+++ b/automations/Modify Central Thermostat/retry-on-failure.yml
@@ -1,0 +1,66 @@
+alias: Heating - RETRY - Attempt to retry main climate TURN_ON automation
+description: >-
+  This automation will attempt to retry setting the main thermostat on the
+  off-chance that the initial automation fails to set to the 'heating'
+  temperature. This is ideal for remote-connected thermostats.
+triggers:
+  - minutes: /2
+    trigger: time_pattern
+conditions:
+  - condition: state
+    entity_id: input_boolean.heating_automation
+    state: "on"
+  - condition: template
+    # Add all your thermostats to this template. 
+    # This will check if any of them are calling for heat.
+    value_template: >
+      {% set therms = [
+        states.climate.YOUR_TRV_CLIMATE_NAME,
+        states.climate.YOUR_TRV_CLIMATE_NAME_2,
+        ] %}
+      {% set climates = namespace(under=[]) %}   {% for therm in therms %}   {%
+      if therm.attributes.current_temperature < therm.attributes.temperature
+      %}   {% set climates.under = climates.under + [ therm.entity_id ] %}  {%
+      endif %} {% endfor %}  {{ climates.under | length > 0 }}
+actions:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: |
+              {{ states('input_number.set_heating_retry_counter') | int < 3 }}
+        sequence:
+          - target:
+              entity_id: input_number.set_heating_retry_counter
+            action: input_number.increment
+            data: {}
+          - data:
+              level: warning
+              message: >
+                "Retry {{ states('input_number.set_heating_retry_counter') | int
+                }}: Nest thermostat remains at an idle temperature while heating
+                is needed."
+            action: system_log.write
+          - target:
+              entity_id: >-
+                automation.heating_boiler_nest_turn_on_boiler_raise_nest_temp_if_any_climates_are_calling_for_heat
+            data:
+              skip_condition: true
+            action: automation.trigger
+      - conditions:
+          - condition: template
+            value_template: |
+              {{ states('input_number.set_heating_retry_counter') | int >= 3 }}
+        sequence:
+          - target:
+              entity_id: input_number.set_heating_retry_counter
+            data:
+              value: 0
+            action: input_number.set_value
+          - data:
+              message: >-
+                "Heating retry failed: Nest thermostat remains idle after 3
+                attempts. Please check the system."
+              title: Heating Automation Fault
+            # make sure you add your mobile phone or device
+            action: notify.YOUR_MOBILE_PHONE_OR_DEVICE
+mode: single

--- a/home_assistant_core/configuration.yml
+++ b/home_assistant_core/configuration.yml
@@ -43,3 +43,13 @@
   end: "{{ now().replace(hour=0, minute=0, second=0) }}"
   duration:
     hours: 24
+
+# Keeps track of heating automation retries
+input_number:
+  set_heating_retry_counter:
+    name: Heating Automation Retry Counter
+    initial: 0
+    min: 0
+    max: 4
+    step: 1
+    mode: box


### PR DESCRIPTION
This introduces an automation which attempts to retry setting a (cloud) connected "Central Themostat."

- This is useful for when a cloud service rate-limits you, or responds with a 4xx/5xx error.
- The automation will attempt 3 times, then send a push notification to alert the user.
- Update documentation (mermaid diagram)
- Add retry `input_number` in `configuration.yml`